### PR TITLE
init: Update Vendor ID check in pff-context-init

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1537,7 +1537,7 @@ static void init_pff(struct switchtec_dev *stdev)
 
 	for (i = 0; i < SWITCHTEC_MAX_PFF_CSR; i++) {
 		reg = ioread16(&stdev->mmio_pff_csr[i].vendor_id);
-		if (reg != PCI_VENDOR_ID_MICROSEMI)
+		if ((reg != PCI_VENDOR_ID_MICROSEMI) && (reg != PCI_VENDOR_ID_EFAR))
 			break;
 	}
 


### PR DESCRIPTION
Recent updates in switchtec driver added support for new Vendor ID, but pff-context-init sequence missed checking new Vendor ID, thus features dependent on PFF context didn't work as expected.

Adding the check will ensure PFF context get initialized properly.