### PR TITLE
Disable DMA MRPC for cascaded devices

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1558,6 +1558,20 @@ static void init_pff(struct switchtec_dev *stdev)
 	}
 }
 
+static bool is_cascaded(struct pci_dev *pdev)
+{
+	struct pci_dev *parent = pdev->bus->self;
+
+	while (parent) {
+		if (parent->vendor == PCI_VENDOR_ID_MICROSEMI ||
+		    parent->vendor == PCI_VENDOR_ID_EFAR)
+			return true;
+		parent = parent->bus->self;
+	}
+
+	return false;
+}
+
 static int switchtec_init_pci(struct switchtec_dev *stdev,
 			      struct pci_dev *pdev)
 {
@@ -1621,6 +1635,9 @@ static int switchtec_init_pci(struct switchtec_dev *stdev,
 	pci_set_drvdata(pdev, stdev);
 
 	if (!use_dma_mrpc)
+		return 0;
+
+	if (is_cascaded(pdev))
 		return 0;
 
 	if (!ioread32(&stdev->mmio_mrpc->dma_ver))


### PR DESCRIPTION
In cascaded topologies (management EP behind another switchtec switch), the DMA MRPC mechanism fails because the firmware's DMA write-back to host memory is an upstream posted TLP that gets blocked traversing the intermediate switch's downstream port (likely due to ACS Source Validation or Requester ID mismatch).

The GAS-based MRPC polling fallback works correctly in cascade because host-initiated MMIO reads to the BAR traverse the cascade without issue, and the event interrupt (MSI-X) for MRPC completion also delivers successfully.

Add is_cascaded() which walks up the PCI topology checking for a Microsemi/EFAR parent bridge. If the device is behind another switchtec switch, skip DMA MRPC allocation so the driver falls back to direct GAS register polling.

Tested on a cascaded PSX 160XG6 setup (FW a.06 B013):
- Direct-attached switch: continues using DMA MRPC with interrupts
- Cascaded switch: uses GAS polling + event IRQ, all commands succeed