### PR TITLE
Add skip for MRPC comp events in ISR loop

### DIFF
--- a/switchtec.c
+++ b/switchtec.c
@@ -1450,7 +1450,12 @@ static irqreturn_t switchtec_event_isr(int irq, void *dev)
 
 	for (eid = 0; eid < SWITCHTEC_IOCTL_MAX_EVENTS; eid++) {
 		if (eid == SWITCHTEC_IOCTL_EVENT_LINK_STATE ||
-		    eid == SWITCHTEC_IOCTL_EVENT_MRPC_COMP)
+		    eid == SWITCHTEC_IOCTL_EVENT_MRPC_COMP ||
+		    eid == SWITCHTEC_IOCTL_EVENT_MRPC_COMP_ASYNC ||
+		    eid == SWITCHTEC_IOCTL_EVENT_TWI_MRPC_COMP ||
+		    eid == SWITCHTEC_IOCTL_EVENT_TWI_MRPC_COMP_ASYNC ||
+		    eid == SWITCHTEC_IOCTL_EVENT_CLI_MRPC_COMP ||
+		    eid == SWITCHTEC_IOCTL_EVENT_CLI_MRPC_COMP_ASYNC)
 			continue;
 
 		event_count += mask_all_events(stdev, eid);


### PR DESCRIPTION
Current implementation just skips the MRPC_COMP, it should also skip the TWI and CLI MRPC completions + ASYNC Ccompletion events too.

The kernel ISR mask_event incorrectly writes back to the GAS register 0x4154 to clear EN_IRQ + OCCURRRED, the firmware event manager write handler interprets that write as an attrs update, which zeros the EVENT_REPORT bit in the MRPC completion Async Header Register.

For these events we want to skip and not write back.